### PR TITLE
Allow the input of user ids

### DIFF
--- a/src/utils/guild-utils.ts
+++ b/src/utils/guild-utils.ts
@@ -12,6 +12,7 @@ export abstract class GuildUtils {
         return (
             members.find(member => member.nickname?.toLowerCase().includes(query)) ??
             members.find(member => member.user.tag.toLowerCase().includes(query)) ??
+            members.find(member => member.user.id.includes(query)) ??
             undefined
         );
     }


### PR DESCRIPTION
Allows Guild Utils to compare the user's input to the user's discord id.